### PR TITLE
fix:修复单元测试中调用函数时的链接错误

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-add_custom_target(Tests)
-add_subdirectory(tests)
-
 # add_definitions("-Wall -g3 -ggdb -Ddebug -DDEBUG")
 
 # 获取所有源代码文件
@@ -88,6 +85,12 @@ file (GLOB SOURCES
 file (GLOB HEADERS
     *.h
 )
+
+set(GLOBAL_SOURCES "${SOURCES}")
+set(GLOBAL_HEADERS "${HEADERS}")
+
+add_custom_target(Tests)
+add_subdirectory(tests)
 
 # .cpp 生成可执行文件
 add_executable(${PROJECT_NAME} ${SOURCES})

--- a/tests/judge_have/CMakeLists.txt
+++ b/tests/judge_have/CMakeLists.txt
@@ -1,0 +1,19 @@
+set(TEST_NAME have_att)
+set(TEST_DESCRIPTION "测试 judge.cpp have_att, have_axe, have_clap_axe 函数")
+
+set(EXEC_NAME test-${TEST_NAME})
+file(GLOB CPP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+option(DISABLE_TEST_${TEST_NAME}, "Disable ${TEST_NAME} test" OFF)
+if(NOT DISABLE_TEST_${TEST_NAME})
+    add_executable(${EXEC_NAME} ${CPP_SOURCES})
+    add_dependencies(Tests ${EXEC_NAME})
+    set_target_properties(${EXEC_NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/tests/bin"
+    )
+    target_link_libraries(${EXEC_NAME} GTest::gtest_main)
+    gtest_discover_tests(${EXEC_NAME})
+    message("测试 ${EXEC_NAME} 已添加")
+else()
+    message("测试 ${TEST_NAME} 将会被忽略")
+endif()

--- a/tests/judge_have/CMakeLists.txt
+++ b/tests/judge_have/CMakeLists.txt
@@ -1,8 +1,12 @@
 set(TEST_NAME have_att)
 set(TEST_DESCRIPTION "测试 judge.cpp have_att, have_axe, have_clap_axe 函数")
+set(TEST_USES_ROOT TRUE) 
 
 set(EXEC_NAME test-${TEST_NAME})
 file(GLOB CPP_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+if(TEST_USES_ROOT)
+    set(CPP_SOURCES "${CPP_SOURCES};${GLOBAL_SOURCES}")
+endif()
 
 option(DISABLE_TEST_${TEST_NAME}, "Disable ${TEST_NAME} test" OFF)
 if(NOT DISABLE_TEST_${TEST_NAME})

--- a/tests/judge_have/main.cpp
+++ b/tests/judge_have/main.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #include <utility>
-#include "../../wooden_judge.cpp"
 
 using std::make_pair;
+using namespace tskl;
 
 #define make_weapon(x) make_pair(0, Skill(x, 1))
 

--- a/tests/judge_have/main.cpp
+++ b/tests/judge_have/main.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <utility>
+#include "../../wooden_judge.cpp"
+
+using std::make_pair;
+
+#define make_weapon(x) make_pair(0, Skill(x, 1))
+
+TEST(FirstTest, BasicAssertions) {
+    EXPECT_EQ(-1, 1);
+}
+
+TEST(have_att_test, BasicAssertions) {
+    EXPECT_TRUE(have_att(make_weapon(tskl::wooden_sword)));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::yellow_sword, 1))));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::stone_sword, 1))));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::iron_sword, 1))));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::gold_sword, 1))));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::diamond_sword, 1))));
+    EXPECT_TRUE(have_att(make_pair(0, Skill(tskl::enchanted_sword, 1))));
+}

--- a/wooden_io.cpp
+++ b/wooden_io.cpp
@@ -1,1 +1,4 @@
+#ifndef WOODEN_IO_CPP
+#define WOODEN_IO_CPP
 #include "wooden_io.h"
+#endif

--- a/wooden_judge.cpp
+++ b/wooden_judge.cpp
@@ -1,3 +1,5 @@
+#ifndef WOODEN_JUDGE_CPP
+#define WOODEN_JUDGE_CPP
 #include "wooden_judge.h"
 
 #include <array>
@@ -1515,3 +1517,4 @@ void passon(const TESTN &test, bool check) {
 }
 
 // 编译环境: C++11
+#endif

--- a/wooden_skill.cpp
+++ b/wooden_skill.cpp
@@ -1,3 +1,5 @@
+#ifndef WOODEN_SKILL_CPP
+#define WOODEN_SKILL_CPP
 #include "wooden_skill.h"
 
 string tskl::query_skill_overlay_name(skill skl) {
@@ -37,3 +39,4 @@ bool tskl::query_skill_is_defense(skill skl) {
     return skl == defense || skl == mid_defense || skl == large_defense ||
            skl == hands || skl == ashiba || skl == zd;
 }
+#endif

--- a/wooden_start.cpp
+++ b/wooden_start.cpp
@@ -1,3 +1,4 @@
+#ifndef WOODEN_START_CPP
 #include <array>
 #include <cassert>
 #include <iostream>
@@ -81,3 +82,4 @@ bool check_internet_connect() {
     // assert(0);
     return false;
 }
+#endif

--- a/wooden_status.cpp
+++ b/wooden_status.cpp
@@ -1,3 +1,4 @@
+#ifndef WOODEN_STATUS_CPP
 #include "wooden_status.h"
 
 #include <utility>
@@ -34,3 +35,4 @@ game_status::game_status(int& _player_num, const std::vector<int>* _players,
     (tag_died) = _tag_died;
     (skl_count) = _skl_count;
 }
+#endif

--- a/wooden_test.cpp
+++ b/wooden_test.cpp
@@ -1,3 +1,4 @@
+#ifndef WOODEN_STATUS_CPP
 #include "wooden_test.h"
 
 #include <cassert>
@@ -329,3 +330,5 @@ const TESTN test14 =
           gen_map<int, int>(2, gen_default_player(2), {0, 1}),
           gen_map<int, bool>(2, gen_default_player(2), {false, true}),
           gen_mapx<int, int>(2, gen_default_player(2), {0, 0}), "单黄局 2");
+
+#endif


### PR DESCRIPTION
commit: ff0364d6e54f1d230559e0ebd0e47b4dffee5065 时编译错误, 原因为函数仅在cpp文件中定义, 这样的定义将无法被外部文件所调用到. 

相关 log: https://github.com/bitsstdcheee/wooden_core/actions/runs/5104006546/jobs/9174644757#step:5:56

因此需要进行声明/定义和实现分离的操作